### PR TITLE
[huntr.dev] 028-JS-NODE-GITLAB-HOOK

### DIFF
--- a/gitlabhook.js
+++ b/gitlabhook.js
@@ -111,7 +111,7 @@ function reply(statusCode, res) {
 }
 
 function executeShellCmds(self, address, data) {
-  var repo = data.repository.name;
+  var repo = data.repository.name.replace(/[&|;$`]/gi, "");
   var lastCommit = data.commits ? data.commits[data.commits.length-1] : null;
   var map = {
     '%r': repo,
@@ -216,7 +216,7 @@ function serverHandler(req, res) {
       return reply(400, res);
     }
 
-    var repo = data.repository.name;
+    var repo = data.repository.name.replace(/[&|;$`]/gi, "");
 
     reply(200, res);
 


### PR DESCRIPTION
**Overview**
Affected versions of this package are vulnerable to Arbitrary Code Execution. Function ExecFile executes commands without any sanitization. User input gets passed directly to this command.

**Remediation**
The fix handles malicious characters (&|;$`) from the repository name.
The repository name is an untrusted input controlled by the user.

**Reference**
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5485
https://hackerone.com/reports/685447
https://snyk.io/vuln/SNYK-JS-GITLABHOOK-466987